### PR TITLE
faster RPC calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Process B:
     })
 
 ```
+
+Alternative Process B:
+```javascript
+  
+  const add = rabbit.setupRequest('add');
+  // send a request
+  add({ num1: 10, num2: 15 })
+    .then(rep => {
+      console.log(rep.result) // 25
+    })
+
+```
 ---
 ### send - listen
 Make a simple sending and receiving of messages in a 1:1 sender:listener fashion. Process B send a message every 1 second to Process A.

--- a/lib/Rabbit.js
+++ b/lib/Rabbit.js
@@ -101,6 +101,35 @@ class Rabbit {
     }
   }
 
+  async setupRequest(queue) {
+    try {
+      const conn = await this.open
+      const channel = await conn.createChannel()
+      const q = await channel.assertQueue('', { exclusive: true })
+
+      const waiters = {};
+
+      channel.consume(q.queue, async (msg) => {
+        if(waiters[msg.properties.correlationId]) {
+          const go = waiters[msg.properties.correlationId];
+          delete waiters[msg.properties.correlationId];
+          go(JSON.parse(msg.content.toString()));
+        }
+      },{ noAck: true });
+      
+      return async (message) => {
+        const correlationId = uuid()
+        await channel.sendToQueue(queue, new Buffer(JSON.stringify(message)), { correlationId, replyTo: q.queue })
+        return new Promise((resolve, reject) => {
+          waiters[correlationId] = resolve;
+        })
+      };
+
+    } catch (error) {
+      throw error
+    }
+  }
+
   async request(queue, message) {
     try {
 


### PR DESCRIPTION
optimize rpc request handling to minimize channe and queue usage

If you use `rabbit.request(...` you will create a new channel and queue for each request.
With the setup method you setup the response queue once. 

(compare: https://www.rabbitmq.com/tutorials/tutorial-six-javascript.html)